### PR TITLE
ser_writedata with ParamsStream of SizeComputer

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -37,7 +37,6 @@ static void SizeComputerBlock(benchmark::Bench& bench) {
     CBlock block;
     DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
 
-    // Create output stream and verify first serialization matches input
     bench.unit("block").run([&] {
         SizeComputer size_computer;
         size_computer << TX_WITH_WITNESS(block);

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -21,6 +21,30 @@
 #include <optional>
 #include <vector>
 
+static void SerializeBlock(benchmark::Bench& bench) {
+    CBlock block;
+    DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
+
+    // Create output stream and verify first serialization matches input
+    bench.unit("block").run([&] {
+        DataStream output_stream;
+        output_stream << TX_WITH_WITNESS(block);
+        assert(output_stream.size() == benchmark::data::block413567.size());
+    });
+}
+
+static void SizeComputerBlock(benchmark::Bench& bench) {
+    CBlock block;
+    DataStream(benchmark::data::block413567) >> TX_WITH_WITNESS(block);
+
+    // Create output stream and verify first serialization matches input
+    bench.unit("block").run([&] {
+        SizeComputer size_computer;
+        size_computer << TX_WITH_WITNESS(block);
+        assert(size_computer.size() == benchmark::data::block413567.size());
+    });
+}
+
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
@@ -60,5 +84,7 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     });
 }
 
+BENCHMARK(SizeComputerBlock, benchmark::PriorityLevel::HIGH);
+BENCHMARK(SerializeBlock, benchmark::PriorityLevel::HIGH);
 BENCHMARK(DeserializeBlockTest, benchmark::PriorityLevel::HIGH);
 BENCHMARK(DeserializeAndCheckBlockTest, benchmark::PriorityLevel::HIGH);

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -96,7 +96,7 @@ void SerializeToVector(Stream& s, const X&... args)
     SizeComputer sizecomp;
     SerializeMany(sizecomp, args...);
     WriteCompactSize(s, sizecomp.size());
-    SerializeMany(s, args...); // TODO preallocate?
+    SerializeMany(s, args...);
 }
 
 // Takes a stream and multiple arguments and unserializes them first as a vector then each object individually in the order provided in the arguments

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -96,7 +96,7 @@ void SerializeToVector(Stream& s, const X&... args)
     SizeComputer sizecomp;
     SerializeMany(sizecomp, args...);
     WriteCompactSize(s, sizecomp.size());
-    SerializeMany(s, args...);
+    SerializeMany(s, args...); // TODO preallocate?
 }
 
 // Takes a stream and multiple arguments and unserializes them first as a vector then each object individually in the order provided in the arguments

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -142,7 +142,11 @@ public:
     {
         unsigned int len = size();
         ::WriteCompactSize(s, len);
-        s << Span{vch, len};
+        if constexpr (ContainsSizeComputer<Stream>) {
+            s.GetStream().seek(len);
+        } else {
+            s << Span{vch, len};
+        }
     }
     template <typename Stream>
     void Unserialize(Stream& s)

--- a/src/streams.h
+++ b/src/streams.h
@@ -69,6 +69,7 @@ public:
     template <typename... Args>
     VectorWriter(std::vector<unsigned char>& vchDataIn, size_t nPosIn, Args&&... args) : VectorWriter{vchDataIn, nPosIn}
     {
+        // TODO preallocate via SizeComputer
         ::SerializeMany(*this, std::forward<Args>(args)...);
     }
     void write(Span<const std::byte> src)

--- a/src/streams.h
+++ b/src/streams.h
@@ -67,10 +67,16 @@ public:
  * @param[in]  args  A list of items to serialize starting at nPosIn.
 */
     template <typename... Args>
-    VectorWriter(std::vector<unsigned char>& vchDataIn, size_t nPosIn, Args&&... args) : VectorWriter{vchDataIn, nPosIn}
+    VectorWriter(std::vector<unsigned char>& vchDataIn, size_t nPosIn, Args&&... args) : vchData{vchDataIn}, nPos{nPosIn}
     {
-        // TODO preallocate via SizeComputer
+        SizeComputer sizecomp;
+        ::SerializeMany(sizecomp, args...);
+        size_t new_size = nPosIn + sizecomp.size();
+        if (new_size > vchData.size())
+            vchData.resize(new_size);
+
         ::SerializeMany(*this, std::forward<Args>(args)...);
+        assert(nPos == new_size);
     }
     void write(Span<const std::byte> src)
     {

--- a/src/streams.h
+++ b/src/streams.h
@@ -75,13 +75,11 @@ public:
     void write(Span<const std::byte> src)
     {
         assert(nPos <= vchData.size());
-        size_t nOverwrite = std::min(src.size(), vchData.size() - nPos);
-        if (nOverwrite) {
-            memcpy(vchData.data() + nPos, src.data(), nOverwrite);
+        size_t new_size = nPos + src.size();
+        if (vchData.size() < new_size) {
+            vchData.resize(new_size);
         }
-        if (nOverwrite < src.size()) {
-            vchData.insert(vchData.end(), UCharCast(src.data()) + nOverwrite, UCharCast(src.end()));
-        }
+        memcpy(vchData.data() + nPos, UCharCast(src.data()), src.size());
         nPos += src.size();
     }
     template <typename T>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <cstring>
 #include <optional>
+#include <serialize.h>
 #include <string>
 #include <string_view>
 
@@ -111,14 +112,16 @@ public:
 
     constexpr uint64_t GetUint64(int pos) const { return ReadLE64(m_data.data() + pos * 8); }
 
-    template<typename Stream>
-    void Serialize(Stream& s) const
+    template<typename Stream> void Serialize(Stream& s) const
     {
-        s << Span(m_data);
+        if constexpr (ContainsSizeComputer<Stream>) {
+            s.GetStream().seek(WIDTH);
+        } else {
+            s << Span(m_data);
+        }
     }
 
-    template<typename Stream>
-    void Unserialize(Stream& s)
+    template<typename Stream> void Unserialize(Stream& s)
     {
         s.read(MakeWritableByteSpan(m_data));
     }


### PR DESCRIPTION
Avoid extra serialization cost (e.g. endianness changes, serializing fixed sizes, etc) when using SizeComputer