### PR TITLE
Fix posted URL & restore mainnet & signet block counts

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -289,5 +289,5 @@ jobs:
         run: |
           gh pr comment ${{ needs.build.outputs.pr-number }} \
             --repo ${{ github.repository }} \
-            --body "📊 Benchmark results for this run (${{ github.event.workflow_run.id }}) will be available at: https://${{ github.repository_owner }}.github.io/${{ github.repository.name }}/results/pr-${{ needs.build.outputs.pr-number }}/${{ github.event.workflow_run.id }}/index.html after the github pages \"build and deployment\" action has completed.
+            --body "📊 Benchmark results for this run (${{ github.event.workflow_run.id }}) will be available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/results/pr-${{ needs.build.outputs.pr-number }}/${{ github.event.workflow_run.id }}/index.html after the github pages \"build and deployment\" action has completed.
           🚀 Speedups: ${{ needs.build.outputs.speedups }}"

--- a/justfile
+++ b/justfile
@@ -33,17 +33,17 @@ build-assumeutxo-binaries base_commit head_commit:
 # Run signet assumeutxo CI workflow
 [group('ci')]
 run-assumeutxo-signet-ci base_commit head_commit TMP_DATADIR UTXO_PATH results_file dbcache png_dir binaries_dir:
-    ./bench-ci/run-assumeutxo-bench.sh {{ base_commit }} {{ head_commit }} {{ TMP_DATADIR }} {{ UTXO_PATH }} {{ results_file }} {{ png_dir }} signet 161000 "148.251.128.115:55555" {{ dbcache }} {{ binaries_dir }}
+    ./bench-ci/run-assumeutxo-bench.sh {{ base_commit }} {{ head_commit }} {{ TMP_DATADIR }} {{ UTXO_PATH }} {{ results_file }} {{ png_dir }} signet 200000 "148.251.128.115:55555" {{ dbcache }} {{ binaries_dir }}
 
 # Run mainnet assumeutxo CI workflow for default cache
 [group('ci')]
 run-assumeutxo-mainnet-default-ci base_commit head_commit TMP_DATADIR UTXO_PATH results_file dbcache png_dir binaries_dir:
-    ./bench-ci/run-assumeutxo-bench.sh {{ base_commit }} {{ head_commit }} {{ TMP_DATADIR }} {{ UTXO_PATH }} {{ results_file }} {{ png_dir }} main 841000 "148.251.128.115:33333" {{ dbcache }} {{ binaries_dir }}
+    ./bench-ci/run-assumeutxo-bench.sh {{ base_commit }} {{ head_commit }} {{ TMP_DATADIR }} {{ UTXO_PATH }} {{ results_file }} {{ png_dir }} main 855000 "148.251.128.115:33333" {{ dbcache }} {{ binaries_dir }}
 
 # Run mainnet assumeutxo CI workflow for large cache
 [group('ci')]
 run-assumeutxo-mainnet-large-ci base_commit head_commit TMP_DATADIR UTXO_PATH results_file dbcache png_dir binaries_dir:
-    ./bench-ci/run-assumeutxo-bench.sh {{ base_commit }} {{ head_commit }} {{ TMP_DATADIR }} {{ UTXO_PATH }} {{ results_file }} {{ png_dir }} main 841000 "148.251.128.115:33333" {{ dbcache }} {{ binaries_dir }}
+    ./bench-ci/run-assumeutxo-bench.sh {{ base_commit }} {{ head_commit }} {{ TMP_DATADIR }} {{ UTXO_PATH }} {{ results_file }} {{ png_dir }} main 855000 "148.251.128.115:33333" {{ dbcache }} {{ binaries_dir }}
 
 # Run a signet benchmark locally
 [group('local')]


### PR DESCRIPTION
default `assumevalid` is block [856760](https://mempool.space/block/000000000000000000011c5890365bdbe5d25b97ce0057589acaef4f1a57263f), so it should be safe to set the limit to 855000 without enabling script validation