### PR TITLE
print logs to console

### DIFF
--- a/bench-ci/run-assumeutxo-bench.sh
+++ b/bench-ci/run-assumeutxo-bench.sh
@@ -64,8 +64,8 @@ prepare_assumeutxo_snapshot_run() {
   clean_datadir "${TMP_DATADIR}"
   # Use the pre-built binaries from BINARIES_DIR
   "${BINARIES_DIR}/${commit}/bitcoind" --help
-  taskset -c 0-15 "${BINARIES_DIR}/${commit}/bitcoind" -datadir="${TMP_DATADIR}" -connect="${CONNECT_ADDRESS}" -daemon=0 -chain="${CHAIN}" -stopatheight=1 -printtoconsole=0
-  taskset -c 0-15 "${BINARIES_DIR}/${commit}/bitcoind" -datadir="${TMP_DATADIR}" -connect="${CONNECT_ADDRESS}" -daemon=0 -chain="${CHAIN}" -dbcache="${DBCACHE}" -pausebackgroundsync=1 -loadutxosnapshot="${UTXO_PATH}" -printtoconsole=0 || true
+  taskset -c 0-15 "${BINARIES_DIR}/${commit}/bitcoind" -datadir="${TMP_DATADIR}" -connect="${CONNECT_ADDRESS}" -daemon=0 -chain="${CHAIN}" -stopatheight=1 -printtoconsole=1 -nodebuglogfile
+  taskset -c 0-15 "${BINARIES_DIR}/${commit}/bitcoind" -datadir="${TMP_DATADIR}" -connect="${CONNECT_ADDRESS}" -daemon=0 -chain="${CHAIN}" -dbcache="${DBCACHE}" -pausebackgroundsync=1 -loadutxosnapshot="${UTXO_PATH}" -printtoconsole=1 -nodebuglogfile || true
   clean_logs "${TMP_DATADIR}"
 }
 

--- a/bench-ci/run-assumeutxo-bench.sh
+++ b/bench-ci/run-assumeutxo-bench.sh
@@ -141,7 +141,7 @@ run_benchmark() {
     --export-json "${results_file}" \
     --command-name "base (${base_commit})" \
     --command-name "head (${head_commit})" \
-    "taskset -c 1 flamegraph --palette bitcoin --title 'bitcoind assumeutxo IBD@{commit}' -c 'record -F 101 --call-graph fp' -- taskset -c 2-15 ${BINARIES_DIR}/{commit}/bitcoind -datadir=${TMP_DATADIR} -connect=${connect_address} -daemon=0 -chain=${chain} -stopatheight=${stop_at_height} -dbcache=${dbcache} -printtoconsole=0 -debug=coindb -debug=leveldb -debug=bench -debug=validation" \
+    "( taskset -c 1 flamegraph --palette bitcoin --title 'bitcoind assumeutxo IBD@{commit}' -c 'record -F 101 --call-graph fp' -- taskset -c 2-15 ${BINARIES_DIR}/{commit}/bitcoind -datadir=${TMP_DATADIR} -connect=${connect_address} -daemon=0 -chain=${chain} -stopatheight=${stop_at_height} -dbcache=${dbcache} -printtoconsole=0 -debug=coindb -debug=leveldb -debug=bench -debug=validation & tail -F ${TMP_DATADIR}/debug.log --pid=\$! )" \
     -L commit "base,head"
 }
 


### PR DESCRIPTION
Test printing more logs to stdout for inspection purposes.

Often it's not clear what's going on in a run without sshing into the runner and inspecting logs. 

Try not to impact performance by letting bitcoind only write to a file (debug.log) and tail that to stdout using another process.