### PR TITLE
SaltedOutpointHasher uses rapidhash

### DIFF
--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -44,5 +44,6 @@ public:
  */
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
 uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
+uint64_t ModifiedRapidHash(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
 
 #endif // BITCOIN_CRYPTO_SIPHASH_H

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -47,7 +47,7 @@ public:
      * @see https://gcc.gnu.org/onlinedocs/gcc-13.2.0/libstdc++/manual/manual/unordered_associative.html
      */
     size_t operator()(const COutPoint& id) const noexcept {
-        return SipHashUint256Extra(k0, k1, id.hash, id.n);
+        return ModifiedRapidHash(k0, k1, id.hash, id.n);
     }
 };
 


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/32128

SipHashUint256Extra is rather slow. For the purpose of generating a hash from a COutPoint and some seed that is only used inside a hashmap, it is sufficient to use a non-cryptographic hash. rapidhash [1] is a well tested and very fast hash function. This implementation strips down this hash function, originally implemented for a memory buffer, to be used with the COutPoint + 2*64bit seed as the input.

[1] https://github.com/Nicoshev/rapidhash
